### PR TITLE
pytz.utz is not an instance of pytz.tzinfo.BaseTzInfo

### DIFF
--- a/timezone_field/fields.py
+++ b/timezone_field/fields.py
@@ -62,7 +62,7 @@ class TimeZoneField(models.Field):
         # inspriation from django's Datetime field
         if value is None or value == '':
             return None
-        if isinstance(value, pytz.tzinfo.BaseTzInfo):
+        if isinstance(value, pytz.tzinfo.BaseTzInfo) or isinstance(value, type(pytz.utc)):
             return value
         if isinstance(value, basestring):
             try:
@@ -77,7 +77,7 @@ class TimeZoneField(models.Field):
         value = self.to_python(value)
         if value is None:
             return ''
-        if isinstance(value, pytz.tzinfo.BaseTzInfo):
+        if isinstance(value, pytz.tzinfo.BaseTzInfo) or isinstance(value, type(pytz.utc)):
             return smart_unicode(value)
 
     def value_to_string(self, value):

--- a/timezone_field/tests.py
+++ b/timezone_field/tests.py
@@ -10,6 +10,7 @@ from timezone_field.fields import TimeZoneField
 
 PST = 'America/Los_Angeles'
 EST = 'America/New_York'
+UTC = 'UTC'
 INVALID_TZ = 'ogga booga'
 
 


### PR DESCRIPTION
Therefore, if you do something like:

> > > mymodel.timezone = 'UTC'
> > > mymodel.save()

You would get an exception saying that mymodel.timezone cannot be null in the DB.

I fixed this by also allowing instances of the UTC class in to_python() and get_prep_value()
