### PR TITLE
Fixes typo that prevented pip from installing correctly

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     description = (
         'A Django app providing database store for pytz timezone objects.'
     ),
-    long_description = open('README').read(),
+    long_description = open('README.rst').read(),
     url = 'http://github.com/mfogel/django-timezone-field/',
     license = 'BSD',
     packages = [


### PR DESCRIPTION
pip install -e git://github.com/mfogel/django-timezone-field.git@master#egg=django_timezone_field-dev was failing with 'No File Found' because README is README.rst
