### PR TITLE
Remove underscore from display name of timezone

### DIFF
--- a/timezone_field/fields.py
+++ b/timezone_field/fields.py
@@ -35,7 +35,7 @@ class TimeZoneField(models.Field):
 
     # NOTE: these defaults are excluded from migrations. If these are changed,
     #       existing migration files will need to be accomodated.
-    CHOICES = [(pytz.timezone(tz), tz) for tz in pytz.common_timezones]
+    CHOICES = [(pytz.timezone(tz), tz.replace('_', ' ')) for tz in pytz.common_timezones]
     MAX_LENGTH = 63
 
     def __init__(self, choices=None, max_length=None, **kwargs):

--- a/timezone_field/fields.py
+++ b/timezone_field/fields.py
@@ -35,7 +35,7 @@ class TimeZoneField(models.Field):
 
     # NOTE: these defaults are excluded from migrations. If these are changed,
     #       existing migration files will need to be accomodated.
-    CHOICES = [(pytz.timezone(tz), tz.replace('_', ' ')) for tz in pytz.common_timezones]
+    CHOICES = [(pytz.timezone(tz), tz) for tz in pytz.common_timezones]
     MAX_LENGTH = 63
 
     def __init__(self, choices=None, max_length=None, **kwargs):
@@ -56,6 +56,8 @@ class TimeZoneField(models.Field):
             if isinstance(choices[0][0], six.string_types):
                 choices = [(pytz.timezone(n1), n2) for n1, n2 in choices]
 
+        choices = [(n1, n2.replace('_', ' ')) for n1, n2 in choices]
+        
         if max_length is None:
             max_length = self.MAX_LENGTH
 


### PR DESCRIPTION
fixes this issue https://github.com/mfogel/django-timezone-field/issues/32

The simple solution would be to do the underscore removing operation in your app's models.py and then feed underscore-less choices into the field with the `choices` arg. 

Not sure if this is a big enough issue to warrant a PR. If so how do you want to proceed with tests. Thoughts?