### PR TITLE
Django 2 Support

### DIFF
--- a/timezone_field/fields.py
+++ b/timezone_field/fields.py
@@ -91,7 +91,7 @@ class TimeZoneField(models.Field):
         value = super(TimeZoneField, self).get_default()
         return self._get_python_and_db_repr(value)[0]
 
-    def from_db_value(self, value, expression, connection, context):
+    def from_db_value(self, value, *args):
         "Convert to pytz timezone object"
         return self._get_python_and_db_repr(value)[0]
 


### PR DESCRIPTION
In Django 2.0 the field `from_db_value()` has a changed argument signature.

This pull request fixes the signature for django 2 and should be backwards compatible with older versions.