### PR TITLE
Accept bytes objects in choices

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -296,8 +296,16 @@ class TimeZoneFieldDeconstructTestCase(TestCase):
             (pytz.timezone('US/Eastern'), 'US/Eastern'),
         ]),
         TimeZoneField(choices=[
+            (pytz.timezone(b'US/Pacific'), b'US/Pacific'),
+            (pytz.timezone(b'US/Eastern'), b'US/Eastern'),
+        ]),
+        TimeZoneField(choices=[
             ('US/Pacific', 'US/Pacific'),
             ('US/Eastern', 'US/Eastern'),
+        ]),
+        TimeZoneField(choices=[
+            (b'US/Pacific', b'US/Pacific'),
+            (b'US/Eastern', b'US/Eastern'),
         ]),
     )
 

--- a/timezone_field/fields.py
+++ b/timezone_field/fields.py
@@ -54,7 +54,7 @@ class TimeZoneField(models.Field):
             # can't deconstruct pytz.timezone objects, migration files must
             # use an alternate format. Representing the timezones as strings
             # is the obvious choice.
-            if isinstance(choices[0][0], six.string_types):
+            if isinstance(choices[0][0], (six.string_types, six.binary_type)):
                 choices = [(pytz.timezone(n1), n2) for n1, n2 in choices]
 
         if max_length is None:


### PR DESCRIPTION
Hello,

Am currently migrating a Py2 project to Py3 and we have a migration with a TimeZoneField defining the choices as bytes.

Ben
