### PR TITLE
RE: Issue #46 | Include GMT offset in timezone choices text

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,8 @@ Form Field
     from timezone_field import TimeZoneFormField
 
     class MyForm(forms.Form):
-        timezone = TimeZoneFormField()
+        timezone = TimeZoneFormField() # displays like "America/Los_Angeles"
+        timezone2 = TimeZoneFormField(display_GMT_offset=True) # displays like "GMT-08:00 America/Los_Angeles"
 
     my_form = MyForm({
         'timezone': 'America/Los_Angeles',

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -10,6 +10,7 @@ from django.test import TestCase
 from django.utils import six
 
 from timezone_field import TimeZoneField, TimeZoneFormField
+from timezone_field.utils import add_gmt_offset_to_choices
 from tests.models import TestModel
 
 
@@ -394,3 +395,28 @@ class TimeZoneFieldDeconstructTestCase(TestCase):
         field = TimeZoneField(choices=choices)
         name, path, args, kwargs = field.deconstruct()
         self.assertNotIn('choices', kwargs)
+
+class GmtOffsetInChoicesTestCase(TestCase):
+
+    # test timezones out of order, but they should appear in order in result.
+    timezones = [
+        (pytz.timezone('US/Eastern'), 'US/Eastern'),
+        (pytz.timezone('US/Pacific'), 'US/Pacific'),
+        (pytz.timezone('Asia/Qatar'), 'Asia/Qatar'),
+        (pytz.timezone('Pacific/Fiji'), 'Pacific/Fiji'),
+        (pytz.timezone('Europe/London'), 'Europe/London'),
+        (pytz.timezone('Pacific/Apia'), 'Pacific/Apia'),
+    ]
+
+    def test_add_gmt_offset_to_choices(self):
+        result = add_gmt_offset_to_choices(self.timezones)
+        expected = [
+            "GMT-11:00 Pacific/Apia",
+            "GMT-08:00 US/Pacific",
+            "GMT-05:00 US/Eastern",
+            "GMT+00:00 Europe/London",
+            "GMT+03:00 Asia/Qatar",
+            "GMT+13:00 Pacific/Fiji",
+        ]
+        for i in range(len(expected)):
+            self.assertEqual(expected[i], result[i][1])

--- a/timezone_field/fields.py
+++ b/timezone_field/fields.py
@@ -139,7 +139,6 @@ class TimeZoneField(models.Field):
         A list of tuples in this format:
         (<pytz.timezone>, <str>)
         """
-        # timezones = pytz.common_timezones_set
         gmt_timezone = pytz.timezone('Greenwich')
         time_ref = datetime(2000, 1, 1)
         time_zero = gmt_timezone.localize(time_ref)

--- a/timezone_field/fields.py
+++ b/timezone_field/fields.py
@@ -1,4 +1,3 @@
-from datetime import datetime, timedelta, time
 import pytz
 
 from django.core.exceptions import ValidationError
@@ -6,7 +5,7 @@ from django.db import models
 from django.utils import six
 from django.utils.encoding import force_text
 
-from timezone_field.utils import is_pytz_instance
+from timezone_field.utils import is_pytz_instance, add_gmt_offset_to_choices
 
 
 class TimeZoneField(models.Field):
@@ -70,7 +69,7 @@ class TimeZoneField(models.Field):
             kwargs['choices'] = [(pytz.timezone(n1), n2) for n1, n2 in choices]
 
         if kwargs['display_GMT_offset']:
-            kwargs['choices'] = self._add_gmt_offset_to_choices(kwargs['choices'])
+            kwargs['choices'] = add_gmt_offset_to_choices(kwargs['choices'])
         kwargs.pop('display_GMT_offset', None)
 
         super(TimeZoneField, self).__init__(*args, **kwargs)
@@ -126,36 +125,3 @@ class TimeZoneField(models.Field):
         except pytz.UnknownTimeZoneError:
             pass
         raise ValidationError("Invalid timezone '%s'" % value)
-
-    def _add_gmt_offset_to_choices(self, timezone_set):
-        """
-        Currently timezone choices items show up like this:
-        'America/New_York'
-
-        But this function formats the choices to display in this format:
-        GMT-05:00 America/New_York
-
-        :return:
-        A list of tuples in this format:
-        (<pytz.timezone>, <str>)
-        """
-        gmt_timezone = pytz.timezone('Greenwich')
-        time_ref = datetime(2000, 1, 1)
-        time_zero = gmt_timezone.localize(time_ref)
-        _choices = []
-        for tz, tz_str in timezone_set:
-            # z = pytz.timezone(tz)
-            delta = (time_zero - tz.localize(time_ref)).total_seconds()
-            h = (datetime.min + timedelta(seconds=delta.__abs__())).hour
-            gmt_diff = time(h).strftime('%H:%M')
-            pair_one = tz
-            pair_two = "GMT{sign}{gmt_diff} {timezone}".format(
-                sign="-" if delta < 0 else "+",
-                gmt_diff=gmt_diff,
-                timezone=tz_str.replace('_', ' ')
-            )
-            _choices.append((delta, pair_one, pair_two))
-
-        _choices.sort(key=lambda x: x[0])
-        choices = [(one, two) for zero, one, two in _choices]
-        return choices

--- a/timezone_field/fields.py
+++ b/timezone_field/fields.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timedelta, time
 import pytz
 
 from django.core.exceptions import ValidationError
@@ -51,6 +52,7 @@ class TimeZoneField(models.Field):
 
         kwargs.setdefault('choices', self.CHOICES)
         kwargs.setdefault('max_length', self.MAX_LENGTH)
+        kwargs.setdefault('display_GMT_offset', False)
 
         # Choices can be specified in two forms: either
         # [<pytz.timezone>, <str>] or [<str>, <str>]
@@ -66,6 +68,10 @@ class TimeZoneField(models.Field):
         choices = kwargs['choices']
         if isinstance(choices[0][0], (six.string_types, six.binary_type)):
             kwargs['choices'] = [(pytz.timezone(n1), n2) for n1, n2 in choices]
+
+        if kwargs['display_GMT_offset']:
+            kwargs['choices'] = self._add_gmt_offset_to_choices(kwargs['choices'])
+        kwargs.pop('display_GMT_offset', None)
 
         super(TimeZoneField, self).__init__(*args, **kwargs)
 
@@ -120,3 +126,37 @@ class TimeZoneField(models.Field):
         except pytz.UnknownTimeZoneError:
             pass
         raise ValidationError("Invalid timezone '%s'" % value)
+
+    def _add_gmt_offset_to_choices(self, timezone_set):
+        """
+        Currently timezone choices items show up like this:
+        'America/New_York'
+
+        But this function formats the choices to display in this format:
+        GMT-05:00 America/New_York
+
+        :return:
+        A list of tuples in this format:
+        (<pytz.timezone>, <str>)
+        """
+        # timezones = pytz.common_timezones_set
+        gmt_timezone = pytz.timezone('Greenwich')
+        time_ref = datetime(2000, 1, 1)
+        time_zero = gmt_timezone.localize(time_ref)
+        _choices = []
+        for tz, tz_str in timezone_set:
+            # z = pytz.timezone(tz)
+            delta = (time_zero - tz.localize(time_ref)).total_seconds()
+            h = (datetime.min + timedelta(seconds=delta.__abs__())).hour
+            gmt_diff = time(h).strftime('%H:%M')
+            pair_one = tz
+            pair_two = "GMT{sign}{gmt_diff} {timezone}".format(
+                sign="-" if delta < 0 else "+",
+                gmt_diff=gmt_diff,
+                timezone=tz
+            )
+            _choices.append((delta, pair_one, pair_two))
+
+        _choices.sort(key=lambda x: x[0])
+        choices = [(one, two) for zero, one, two in _choices]
+        return choices

--- a/timezone_field/fields.py
+++ b/timezone_field/fields.py
@@ -152,7 +152,7 @@ class TimeZoneField(models.Field):
             pair_two = "GMT{sign}{gmt_diff} {timezone}".format(
                 sign="-" if delta < 0 else "+",
                 gmt_diff=gmt_diff,
-                timezone=tz
+                timezone=tz_str.replace('_', ' ')
             )
             _choices.append((delta, pair_one, pair_two))
 

--- a/timezone_field/utils.py
+++ b/timezone_field/utils.py
@@ -1,5 +1,38 @@
 import pytz
-
+from datetime import datetime, timedelta, time
 
 def is_pytz_instance(value):
     return value is pytz.UTC or isinstance(value, pytz.tzinfo.BaseTzInfo)
+
+def add_gmt_offset_to_choices(timezone_tuple_set):
+    """
+    Currently timezone choices items show up like this:
+    'America/New_York'
+
+    But this function formats the choices to display in this format:
+    GMT-05:00 America/New_York
+
+    :return:
+    A list of tuples in this format:
+    (<pytz.timezone>, <str>)
+    """
+    gmt_timezone = pytz.timezone('Greenwich')
+    time_ref = datetime(2000, 1, 1)
+    time_zero = gmt_timezone.localize(time_ref)
+    _choices = []
+    for tz, tz_str in timezone_tuple_set:
+        # z = pytz.timezone(tz)
+        delta = (time_zero - tz.localize(time_ref)).total_seconds()
+        h = (datetime.min + timedelta(seconds=delta.__abs__())).hour
+        gmt_diff = time(h).strftime('%H:%M')
+        pair_one = tz
+        pair_two = "GMT{sign}{gmt_diff} {timezone}".format(
+            sign="-" if delta < 0 else "+",
+            gmt_diff=gmt_diff,
+            timezone=tz_str.replace('_', ' ')
+        )
+        _choices.append((delta, pair_one, pair_two))
+
+    _choices.sort(key=lambda x: x[0])
+    choices = [(one, two) for zero, one, two in _choices]
+    return choices

--- a/timezone_field/utils.py
+++ b/timezone_field/utils.py
@@ -21,7 +21,6 @@ def add_gmt_offset_to_choices(timezone_tuple_set):
     time_zero = gmt_timezone.localize(time_ref)
     _choices = []
     for tz, tz_str in timezone_tuple_set:
-        # z = pytz.timezone(tz)
         delta = (time_zero - tz.localize(time_ref)).total_seconds()
         h = (datetime.min + timedelta(seconds=delta.__abs__())).hour
         gmt_diff = time(h).strftime('%H:%M')


### PR DESCRIPTION
Hi,

This is my first ever contribution to public GitHub projects. I have made it optional like originally requested. I have given my first attempt. Please suggest any helpful advice. 

Here is a screenshot:
<img width="690" alt="screen shot 2018-12-14 at 7 28 53 pm" src="https://user-images.githubusercontent.com/36269023/50036742-3fe8af00-ffd9-11e8-8651-7e980c392cba.png">

Sincerely,
SM
