### PR TITLE
Use force_str() instead of force_text()

### DIFF
--- a/timezone_field/fields.py
+++ b/timezone_field/fields.py
@@ -3,7 +3,7 @@ import pytz
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.utils import six
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 
 from timezone_field.utils import is_pytz_instance, add_gmt_offset_to_choices
 
@@ -121,7 +121,7 @@ class TimeZoneField(models.Field):
         if is_pytz_instance(value):
             return (value, value.zone)
         try:
-            return (pytz.timezone(force_text(value)), force_text(value))
+            return (pytz.timezone(force_str(value)), force_str(value))
         except pytz.UnknownTimeZoneError:
             pass
         raise ValidationError("Invalid timezone '%s'" % value)


### PR DESCRIPTION
```
timezone_field/fields.py:124: RemovedInDjango40Warning: force_text() is deprecated in favor of force_str().
  return (pytz.timezone(force_text(value)), force_text(value))
```