### PR TITLE
Convert TimeZoneField string value to timezone object on assignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ my_model.full_clean() # validates against pytz.common_timezones by default
 my_model.save()       # values stored in DB as strings
 my_model.tz3          # value returned as pytz timezone: <DstTzInfo 'America/Vancouver' LMT-1 day, 15:48:00 STD>
 my_model.tz4          # value returned as zoneinfo: zoneinfo.ZoneInfo(key='America/Vancouver')
+
+my_model.tz1 = "UTC"  # assignment of a string, immediately converted to timezone object
+my_model.tz1          # zoneinfo.ZoneInfo(key='UTC') or pytz.utc, depending on use_pytz default
+my_model.tz2 = "Invalid/Not_A_Zone"  # immediately raises ValidationError
 ```
 
 ### Form Field
@@ -133,6 +137,14 @@ poetry run pytest
 ```
 
 ## Changelog
+
+#### `main` (unreleased)
+
+- Convert string value to timezone object immediately on creation/assignment.
+  Accessing a TimeZoneField will _always_ return a timezone or None (never a string).
+  (Potentially BREAKING: Unknown timezone names now raise `ValidationError` at time of assignment.
+  Previously, conversion was delayed until model `full_clean` or `save`.) 
+  ([#57](https://github.com/mfogel/django-timezone-field/issues/57))
 
 #### 6.1.0 (2023-11-25)
 

--- a/timezone_field/fields.py
+++ b/timezone_field/fields.py
@@ -4,6 +4,7 @@ from django.utils.encoding import force_str
 
 from timezone_field.backends import TimeZoneNotFoundError, get_tz_backend
 from timezone_field.choices import standard, with_gmt_offset
+from timezone_field.utils import AutoDeserializedAttribute
 
 
 class TimeZoneField(models.Field):
@@ -34,6 +35,8 @@ class TimeZoneField(models.Field):
     [<timezone object>, <str>] or [<str>, <str>]. Internally in memory, it is
     stored as [<timezone object>, <str>].
     """
+
+    descriptor_class = AutoDeserializedAttribute
 
     description = "A timezone object"
 

--- a/timezone_field/utils.py
+++ b/timezone_field/utils.py
@@ -1,0 +1,19 @@
+from django.db.models.query_utils import DeferredAttribute
+
+
+class AutoDeserializedAttribute(DeferredAttribute):
+    """
+    Use as the descriptor_class for a Django custom field.
+    Allows setting the field to a serialized (typically string) value,
+    and immediately reflecting that as the deserialized `to_python` value.
+
+    (This requires that the field's `to_python` returns the same thing
+    whether called with a serialized or deserialized value.)
+    """
+
+    # (Adapted from django.db.models.fields.subclassing.Creator,
+    # which was included in Django 1.8 and earlier.)
+
+    def __set__(self, instance, value):
+        value = self.field.to_python(value)
+        instance.__dict__[self.field.attname] = value


### PR DESCRIPTION
Add a descriptor_class that deserializes a string TimeZoneField value to a timezone object (pytz timezone or zoneinfo depending on settings) when it is assigned.

As a side effect, invalid (non-blank) timezone names are detected immediately (rather than at save/full_clean time), and will immediately raise a ValidationError.

Closes #57

~~[There are two commits in this PR. The first, simpler one works for Django 3.0+. The second carries support back to Django 2.2. But if you're dropping Django 2.2 support soon anyway (it exited extended support a year ago), there's no reason to add that extra complication.]~~
