### PR TITLE
Fixes to get_tz_backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,10 @@ poetry run pytest
 
 ## Changelog
 
+#### `main` (not yet released to pypi)
+
+- Use correct default backend when running with django 3.X ([#109](https://github.com/mfogel/django-timezone-field/issues/109))
+
 #### 6.0 (2023-08-20)
 
 - BREAKING: `pytz` removed from dependencies. If you use this package with `use_pytz=True`, you'll need to install

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -96,25 +96,25 @@ def use_pytz(request):
 
 @pytest.fixture
 def to_tzobj(use_pytz):
-    tz_backend = backends.get_tz_backend(use_pytz=use_pytz)
+    tz_backend = backends.get_tz_backend(use_pytz)
     yield tz_backend.to_tzobj
 
 
 @pytest.fixture
 def utc_tzobj(use_pytz):
-    tz_backend = backends.get_tz_backend(use_pytz=use_pytz)
+    tz_backend = backends.get_tz_backend(use_pytz)
     yield tz_backend.utc_tzobj
 
 
 @pytest.fixture
 def all_tzstrs(use_pytz):
-    tz_backend = backends.get_tz_backend(use_pytz=use_pytz)
+    tz_backend = backends.get_tz_backend(use_pytz)
     yield tz_backend.all_tzstrs
 
 
 @pytest.fixture
 def base_tzstrs(use_pytz):
-    tz_backend = backends.get_tz_backend(use_pytz=use_pytz)
+    tz_backend = backends.get_tz_backend(use_pytz)
     yield tz_backend.base_tzstrs
 
 

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -1,7 +1,11 @@
 from django import VERSION
 
-from timezone_field.backends import USE_PYTZ_DEFAULT
+from timezone_field.backends import USE_PYTZ_DEFAULT, get_tz_backend
 
 
 def test_use_pytz_default_USE_DEPRECATED_PYTZ_unset():
     assert USE_PYTZ_DEFAULT is (VERSION < (4, 0))
+
+
+def test_get_tz_backend_when_use_pytz_is_none():
+    assert get_tz_backend(use_pytz=None) is USE_PYTZ_DEFAULT

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -8,4 +8,4 @@ def test_use_pytz_default_USE_DEPRECATED_PYTZ_unset():
 
 
 def test_get_tz_backend_when_use_pytz_is_none():
-    assert get_tz_backend(use_pytz=None) is USE_PYTZ_DEFAULT
+    assert get_tz_backend(None) is USE_PYTZ_DEFAULT

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -1,6 +1,8 @@
 from django import VERSION
 
 from timezone_field.backends import USE_PYTZ_DEFAULT, get_tz_backend
+from timezone_field.backends.pytz import PYTZBackend
+from timezone_field.backends.zoneinfo import ZoneInfoBackend
 
 
 def test_use_pytz_default_USE_DEPRECATED_PYTZ_unset():
@@ -9,3 +11,11 @@ def test_use_pytz_default_USE_DEPRECATED_PYTZ_unset():
 
 def test_get_tz_backend_when_use_pytz_is_none():
     assert get_tz_backend(None) is get_tz_backend(USE_PYTZ_DEFAULT)
+
+
+def test_get_tz_backend_when_use_pytz_is_true():
+    assert isinstance(get_tz_backend(True), PYTZBackend)
+
+
+def test_get_tz_backend_when_use_pytz_is_false():
+    assert isinstance(get_tz_backend(False), ZoneInfoBackend)

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -8,4 +8,4 @@ def test_use_pytz_default_USE_DEPRECATED_PYTZ_unset():
 
 
 def test_get_tz_backend_when_use_pytz_is_none():
-    assert get_tz_backend(None) is USE_PYTZ_DEFAULT
+    assert get_tz_backend(None) is get_tz_backend(USE_PYTZ_DEFAULT)

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -1,7 +1,6 @@
 from django import VERSION
 
 from timezone_field.backends import USE_PYTZ_DEFAULT, get_tz_backend
-from timezone_field.backends.pytz import PYTZBackend
 from timezone_field.backends.zoneinfo import ZoneInfoBackend
 
 
@@ -13,9 +12,15 @@ def test_get_tz_backend_when_use_pytz_is_none():
     assert get_tz_backend(None) is get_tz_backend(USE_PYTZ_DEFAULT)
 
 
-def test_get_tz_backend_when_use_pytz_is_true():
-    assert isinstance(get_tz_backend(True), PYTZBackend)
-
-
 def test_get_tz_backend_when_use_pytz_is_false():
     assert isinstance(get_tz_backend(False), ZoneInfoBackend)
+
+
+try:
+    from timezone_field.backends.pytz import PYTZBackend
+except ImportError:
+    pass
+finally:
+
+    def test_get_tz_backend_when_use_pytz_is_true():
+        assert isinstance(get_tz_backend(True), PYTZBackend)

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -20,7 +20,7 @@ try:
     from timezone_field.backends.pytz import PYTZBackend
 except ImportError:
     pass
-finally:
+else:
 
     def test_get_tz_backend_when_use_pytz_is_true():
         assert isinstance(get_tz_backend(True), PYTZBackend)

--- a/timezone_field/backends/__init__.py
+++ b/timezone_field/backends/__init__.py
@@ -7,7 +7,8 @@ USE_PYTZ_DEFAULT = getattr(conf.settings, "USE_DEPRECATED_PYTZ", VERSION < (4, 0
 tz_backend_cache = {}
 
 
-def get_tz_backend(use_pytz=USE_PYTZ_DEFAULT):
+def get_tz_backend(use_pytz):
+    use_pytz = USE_PYTZ_DEFAULT if use_pytz is None else use_pytz
     if use_pytz not in tz_backend_cache:
         if use_pytz:
             from .pytz import PYTZBackend

--- a/timezone_field/choices.py
+++ b/timezone_field/choices.py
@@ -26,7 +26,7 @@ def with_gmt_offset(timezones, now=None, use_pytz=None):
           underscores. For example: "GMT-05:00 America/New York"
         * sorted by their timezone offset
     """
-    tz_backend = get_tz_backend(use_pytz=use_pytz)
+    tz_backend = get_tz_backend(use_pytz)
     now = now or datetime.datetime.now(tz_backend.utc_tzobj)
     _choices = []
     for tz in timezones:

--- a/timezone_field/fields.py
+++ b/timezone_field/fields.py
@@ -50,7 +50,7 @@ class TimeZoneField(models.Field):
         kwargs.setdefault("max_length", self.default_max_length)
 
         self.use_pytz = kwargs.pop("use_pytz", None)
-        self.tz_backend = get_tz_backend(use_pytz=self.use_pytz)
+        self.tz_backend = get_tz_backend(self.use_pytz)
         self.default_tzs = [self.tz_backend.to_tzobj(v) for v in self.tz_backend.base_tzstrs]
 
         if "choices" in kwargs:

--- a/timezone_field/forms.py
+++ b/timezone_field/forms.py
@@ -18,7 +18,7 @@ def get_coerce(tz_backend):
 class TimeZoneFormField(forms.TypedChoiceField):
     def __init__(self, *args, **kwargs):
         self.use_pytz = kwargs.pop("use_pytz", None)
-        self.tz_backend = get_tz_backend(use_pytz=self.use_pytz)
+        self.tz_backend = get_tz_backend(self.use_pytz)
         kwargs.setdefault("coerce", get_coerce(self.tz_backend))
         kwargs.setdefault("empty_value", None)
 


### PR DESCRIPTION
This function was broken when passed `use_pytz=None`, as detailed by #109.

Fixes #109 