### PR TITLE
backends/zoneinfo.py: Skip using the "Factory" timezone

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ poetry run pytest
 #### `main` (unreleased!)
 
 - Add support for django 5.0
+- Fix issue with `Factory` timezone on some BSD systems ([#114](https://github.com/mfogel/django-timezone-field/issues/114))
 
 #### 6.0.1 (2023-09-07)
 

--- a/timezone_field/backends/zoneinfo.py
+++ b/timezone_field/backends/zoneinfo.py
@@ -10,6 +10,10 @@ class ZoneInfoBackend(TimeZoneBackend):
     utc_tzobj = zoneinfo.ZoneInfo("UTC")
     all_tzstrs = zoneinfo.available_timezones()
     base_tzstrs = zoneinfo.available_timezones()
+    # Remove the "Factory" timezone as it can cause ValueError exceptions on
+    # some systems, e.g. FreeBSD, if the system zoneinfo database is used.
+    all_tzstrs.discard("Factory")
+    base_tzstrs.discard("Factory")
 
     def is_tzobj(self, value):
         return isinstance(value, zoneinfo.ZoneInfo)


### PR DESCRIPTION
Referencing the "Factory" timezone can lead to ValueError exceptions on some systems, e.g. FreeBSD, if the system zoneinfo database is used:

ValueError: Invalid STD format in b'<Local time zone must be set--use tzsetup>0'

Thus drop the "Factory" timezone from the sets before iterating over them to avoid the aforementioned issue.

This should fix #114 .