### PR TITLE
Upgrade GitHub Actions and Django v5.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
       - name: Git checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: "3.12"
 
@@ -56,7 +56,7 @@ jobs:
       matrix:
         # https://docs.djangoproject.com/en/4.1/faq/install/#what-python-version-can-i-use-with-django
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-        django-version: ["3.2", "4.0", "4.1", "4.2", "5.0rc1"]
+        django-version: ["3.2", "4.0", "4.1", "4.2", "5.0"]
         db-engine: [sqlite, postgres]
         tz-engine: [pytz, zoneinfo]
         exclude:
@@ -72,11 +72,11 @@ jobs:
             python-version: "3.12"
           - django-version: "4.1"
             python-version: "3.12"
-          - django-version: "5.0rc1"
+          - django-version: "5.0"
             python-version: "3.8"
-          - django-version: "5.0rc1"
+          - django-version: "5.0"
             python-version: "3.9"
-          - django-version: "5.0rc1"
+          - django-version: "5.0"
             tz-engine: pytz
 
     env:
@@ -100,10 +100,10 @@ jobs:
 
     steps:
       - name: Git checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -176,10 +176,10 @@ jobs:
 
     steps:
       - name: Git checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: "3.12"
 


### PR DESCRIPTION
Upgrading our project from Django v4.2 to v5.0 ___downgraded___ our version of django-timezone-field!

`Pipfile.lock`:
```diff
        "django-timezone-field": {
-           "markers": "python_version >= '3.8' and python_version < '4.0'",
-           "version": "==6.1.0"
+           "markers": "python_version >= '3.5'",
+           "version": "==4.2.3"
```