### PR TITLE
Change base class of TimeZoneSerializerField from DJRF's Field to CharField

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ poetry run pytest
   ([#57](https://github.com/mfogel/django-timezone-field/issues/57))
 - Add support for django 5.1
 - Drop support for django 3.2, 4.0, 4.1
+- Change subclass of `TimeZoneSerializerField` from DJRF's `Field` to `CharField` ([#137](https://github.com/mfogel/django-timezone-field/issues/137))
 
 #### 6.1.0 (2023-11-25)
 

--- a/tests/test_serializer_field.py
+++ b/tests/test_serializer_field.py
@@ -12,6 +12,7 @@ def TimeZoneSerializer(use_pytz):
 
     yield _TimeZoneSerializer
 
+
 @pytest.fixture
 def TimeZoneSerializerEmpties(use_pytz):
     class _TimeZoneSerializer(serializers.Serializer):
@@ -70,11 +71,13 @@ def test_valid_empties(TimeZoneSerializerEmpties):
 
 
 def test_invalid_empties(TimeZoneSerializerEmpties):
-    serializer = TimeZoneSerializerEmpties(data={
-        "tz_allow_null": "",
-        "tz_allow_blank": None,
-        "tz_not_required": None,
-    })
+    serializer = TimeZoneSerializerEmpties(
+        data={
+            "tz_allow_null": "",
+            "tz_allow_blank": None,
+            "tz_not_required": None,
+        }
+    )
     assert not serializer.is_valid()
     assert serializer.data == {"tz_allow_null": "", "tz_allow_blank": None, "tz_not_required": None}
     assert serializer.validated_data == {}

--- a/tests/test_serializer_field.py
+++ b/tests/test_serializer_field.py
@@ -12,6 +12,14 @@ def TimeZoneSerializer(use_pytz):
 
     yield _TimeZoneSerializer
 
+@pytest.fixture
+def TimeZoneSerializerAllowNull(use_pytz):
+    class _TimeZoneSerializer(serializers.Serializer):
+        # pylint: disable=abstract-method
+        tz = TimeZoneSerializerField(use_pytz=use_pytz, allow_null=True)
+
+    yield _TimeZoneSerializer
+
 
 def test_invalid_str(TimeZoneSerializer, invalid_tz):
     serializer = TimeZoneSerializer(data={"tz": invalid_tz})
@@ -41,3 +49,14 @@ def test_valid_with_timezone_object(TimeZoneSerializer, pst, pst_tz):
     assert serializer.is_valid()
     assert serializer.data["tz"] == pst
     assert serializer.validated_data["tz"] == pst_tz
+
+
+def test_allow_null(TimeZoneSerializer, TimeZoneSerializerAllowNull):
+    serializer_disallow_null = TimeZoneSerializer(data={"tz": None})
+    serializer_allow_null = TimeZoneSerializerAllowNull(data={"tz": None})
+    assert serializer_disallow_null.is_valid() is False
+    assert serializer_disallow_null.data == {"tz": None}
+    assert serializer_disallow_null.validated_data == {}
+    assert serializer_allow_null.is_valid()
+    assert serializer_allow_null.data == {"tz": None}
+    assert serializer_allow_null.validated_data == {"tz": None}

--- a/tests/test_serializer_field.py
+++ b/tests/test_serializer_field.py
@@ -13,10 +13,11 @@ def TimeZoneSerializer(use_pytz):
     yield _TimeZoneSerializer
 
 @pytest.fixture
-def TimeZoneSerializerAllowNull(use_pytz):
+def TimeZoneSerializerEmpties(use_pytz):
     class _TimeZoneSerializer(serializers.Serializer):
         # pylint: disable=abstract-method
-        tz = TimeZoneSerializerField(use_pytz=use_pytz, allow_null=True)
+        tz_allow_null = TimeZoneSerializerField(use_pytz=use_pytz, allow_null=True)
+        tz_allow_blank = TimeZoneSerializerField(use_pytz=use_pytz, allow_blank=True)
 
     yield _TimeZoneSerializer
 
@@ -30,6 +31,15 @@ def test_invalid_str(TimeZoneSerializer, invalid_tz):
 def test_empty_str(TimeZoneSerializer):
     serializer = TimeZoneSerializer(data={"tz": ""})
     assert not serializer.is_valid()
+    assert serializer.data == {"tz": ""}
+    assert serializer.validated_data == {}
+
+
+def test_none(TimeZoneSerializer):
+    serializer = TimeZoneSerializer(data={"tz": None})
+    assert not serializer.is_valid()
+    assert serializer.data == {"tz": None}
+    assert serializer.validated_data == {}
 
 
 def test_valid(TimeZoneSerializer, pst, pst_tz):
@@ -51,12 +61,15 @@ def test_valid_with_timezone_object(TimeZoneSerializer, pst, pst_tz):
     assert serializer.validated_data["tz"] == pst_tz
 
 
-def test_allow_null(TimeZoneSerializer, TimeZoneSerializerAllowNull):
-    serializer_disallow_null = TimeZoneSerializer(data={"tz": None})
-    serializer_allow_null = TimeZoneSerializerAllowNull(data={"tz": None})
-    assert serializer_disallow_null.is_valid() is False
-    assert serializer_disallow_null.data == {"tz": None}
-    assert serializer_disallow_null.validated_data == {}
-    assert serializer_allow_null.is_valid()
-    assert serializer_allow_null.data == {"tz": None}
-    assert serializer_allow_null.validated_data == {"tz": None}
+def test_valid_empties(TimeZoneSerializerEmpties):
+    serializer = TimeZoneSerializerEmpties(data={"tz_allow_null": None, "tz_allow_blank": ""})
+    assert serializer.is_valid()
+    assert serializer.data == {"tz_allow_null": None, "tz_allow_blank": ""}
+    assert serializer.validated_data == {"tz_allow_null": None, "tz_allow_blank": ""}
+
+
+def test_invalid_empties(TimeZoneSerializerEmpties):
+    serializer = TimeZoneSerializerEmpties(data={"tz_allow_null": "", "tz_allow_blank": None})
+    assert not serializer.is_valid()
+    assert serializer.data == {"tz_allow_null": "", "tz_allow_blank": None}
+    assert serializer.validated_data == {}

--- a/tests/test_serializer_field.py
+++ b/tests/test_serializer_field.py
@@ -18,6 +18,7 @@ def TimeZoneSerializerEmpties(use_pytz):
         # pylint: disable=abstract-method
         tz_allow_null = TimeZoneSerializerField(use_pytz=use_pytz, allow_null=True)
         tz_allow_blank = TimeZoneSerializerField(use_pytz=use_pytz, allow_blank=True)
+        tz_not_required = TimeZoneSerializerField(use_pytz=use_pytz, required=False)
 
     yield _TimeZoneSerializer
 
@@ -69,7 +70,11 @@ def test_valid_empties(TimeZoneSerializerEmpties):
 
 
 def test_invalid_empties(TimeZoneSerializerEmpties):
-    serializer = TimeZoneSerializerEmpties(data={"tz_allow_null": "", "tz_allow_blank": None})
+    serializer = TimeZoneSerializerEmpties(data={
+        "tz_allow_null": "",
+        "tz_allow_blank": None,
+        "tz_not_required": None,
+    })
     assert not serializer.is_valid()
-    assert serializer.data == {"tz_allow_null": "", "tz_allow_blank": None}
+    assert serializer.data == {"tz_allow_null": "", "tz_allow_blank": None, "tz_not_required": None}
     assert serializer.validated_data == {}

--- a/timezone_field/rest_framework.py
+++ b/timezone_field/rest_framework.py
@@ -1,11 +1,11 @@
 from django.utils.encoding import force_str
 from django.utils.translation import gettext_lazy as _
-from rest_framework.fields import Field
+from rest_framework.fields import CharField
 
 from timezone_field.backends import TimeZoneNotFoundError, get_tz_backend
 
 
-class TimeZoneSerializerField(Field):
+class TimeZoneSerializerField(CharField):
     default_error_messages = {
         "invalid": _("A valid timezone is required."),
     }


### PR DESCRIPTION
## What

- change base class of TimeZoneSerializerField from DJRF's `Field` to `CharField`
- add tests to ensure the `required`, `allow_null`, and `allow_blank` kwargs are all working [as documented by DJRF](https://www.django-rest-framework.org/community/3.0-announcement/#the-required-allow_null-allow_blank-and-default-arguments)

## Why

Subclassing `Field` introduces some situations where it isn't clear what the correct behavior is. DJRF addressed this for `CharField` in their 3.0 release - let's leverage their solution here.

Closes #130 