### PR TITLE
Lazy-load zoneinfo to improve startup time

### DIFF
--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -1,8 +1,12 @@
+from unittest.mock import patch
+
 import pytest
+import zoneinfo
 from django.core.exceptions import ValidationError
 from pytest_lazy_fixtures import lf as lazy_fixture
 
 from timezone_field import TimeZoneField
+from timezone_field.backends.zoneinfo import ZoneInfoBackend
 
 pytestmark = pytest.mark.filterwarnings("ignore:Model 'tests._model.*' was already registered.")
 
@@ -129,3 +133,22 @@ def test_with_limited_choices_old_format_invalid_choice(ModelOldChoiceFormat, kw
     with pytest.raises(ValidationError):
         m = ModelOldChoiceFormat(**kwargs)
         m.full_clean()
+
+
+def test_lazy_timezone_loading():
+    """TimeZoneField construction should not call available_timezones()."""
+    # Use a fresh backend instance so cached_property hasn't fired
+    backend = ZoneInfoBackend()
+
+    with (
+        patch.object(
+            zoneinfo, "available_timezones", wraps=zoneinfo.available_timezones
+        ) as mock_at,
+        patch("timezone_field.fields.get_tz_backend", return_value=backend),
+    ):
+        field = TimeZoneField()
+        assert mock_at.call_count == 0, "available_timezones() called during TimeZoneField construction"
+
+        # Accessing choices should trigger the lazy load
+        list(field.choices)
+        assert mock_at.call_count > 0, "available_timezones() should be called after accessing choices"

--- a/timezone_field/backends/zoneinfo.py
+++ b/timezone_field/backends/zoneinfo.py
@@ -1,3 +1,5 @@
+from functools import cached_property
+
 try:
     import zoneinfo
 except ImportError:
@@ -7,13 +9,21 @@ from .base import TimeZoneBackend, TimeZoneNotFoundError
 
 
 class ZoneInfoBackend(TimeZoneBackend):
-    utc_tzobj = zoneinfo.ZoneInfo("UTC")
-    all_tzstrs = zoneinfo.available_timezones()
-    base_tzstrs = zoneinfo.available_timezones()
-    # Remove the "Factory" timezone as it can cause ValueError exceptions on
-    # some systems, e.g. FreeBSD, if the system zoneinfo database is used.
-    all_tzstrs.discard("Factory")
-    base_tzstrs.discard("Factory")
+    @cached_property
+    def utc_tzobj(self):
+        return zoneinfo.ZoneInfo("UTC")
+
+    @cached_property
+    def all_tzstrs(self):
+        tzstrs = zoneinfo.available_timezones()
+        # Remove the "Factory" timezone as it can cause ValueError exceptions on
+        # some systems, e.g. FreeBSD, if the system zoneinfo database is used.
+        tzstrs.discard("Factory")
+        return tzstrs
+
+    @cached_property
+    def base_tzstrs(self):
+        return self.all_tzstrs
 
     def is_tzobj(self, value):
         return isinstance(value, zoneinfo.ZoneInfo)

--- a/timezone_field/backends/zoneinfo.py
+++ b/timezone_field/backends/zoneinfo.py
@@ -1,4 +1,4 @@
-from functools import cached_property
+from django.utils.functional import cached_property
 
 try:
     import zoneinfo

--- a/timezone_field/fields.py
+++ b/timezone_field/fields.py
@@ -1,6 +1,9 @@
+from functools import cached_property
+
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.utils.encoding import force_str
+from django.utils.functional import SimpleLazyObject
 
 from timezone_field.backends import TimeZoneNotFoundError, get_tz_backend
 from timezone_field.choices import standard, with_gmt_offset
@@ -44,6 +47,10 @@ class TimeZoneField(models.Field):
     #       existing migration files will need to be accomodated.
     default_max_length = 63
 
+    @cached_property
+    def default_tzs(self):
+        return [self.tz_backend.to_tzobj(v) for v in self.tz_backend.base_tzstrs]
+
     def __init__(self, *args, **kwargs):
         # allow some use of positional args up until the args we customize
         # https://github.com/mfogel/django-timezone-field/issues/42
@@ -54,10 +61,21 @@ class TimeZoneField(models.Field):
 
         self.use_pytz = kwargs.pop("use_pytz", None)
         self.tz_backend = get_tz_backend(self.use_pytz)
-        self.default_tzs = [self.tz_backend.to_tzobj(v) for v in self.tz_backend.base_tzstrs]
+        self.choices_display = kwargs.pop("choices_display", None)
+        if self.choices_display not in (None, "WITH_GMT_OFFSET", "STANDARD"):
+            raise ValueError(f"Unrecognized value for kwarg 'choices_display' of '{self.choices_display}'")
 
         if "choices" in kwargs:
-            values, displays = zip(*kwargs["choices"])
+            self._raw_choices = list(kwargs["choices"])
+        else:
+            self._raw_choices = None
+
+        kwargs["choices"] = SimpleLazyObject(self._build_choices)
+        super().__init__(*args, **kwargs)
+
+    def _build_choices(self):
+        if self._raw_choices is not None:
+            values, displays = zip(*self._raw_choices)
             # Choices can be specified in two forms: either
             # [<timezone object>, <str>] or [<str>, <str>]
             #
@@ -76,18 +94,15 @@ class TimeZoneField(models.Field):
             values = self.default_tzs
             displays = None
 
-        self.choices_display = kwargs.pop("choices_display", None)
         if self.choices_display == "WITH_GMT_OFFSET":
             choices = with_gmt_offset(values, use_pytz=self.use_pytz)
         elif self.choices_display == "STANDARD":
             choices = standard(values)
         elif self.choices_display is None:
-            choices = zip(values, displays) if displays else standard(values)
+            choices = list(zip(values, displays)) if displays else standard(values)
         else:
             raise ValueError(f"Unrecognized value for kwarg 'choices_display' of '{self.choices_display}'")
-
-        kwargs["choices"] = choices
-        super().__init__(*args, **kwargs)
+        return choices
 
     def validate(self, value, model_instance):
         if not self.tz_backend.is_tzobj(value):

--- a/timezone_field/fields.py
+++ b/timezone_field/fields.py
@@ -1,9 +1,7 @@
-from functools import cached_property
-
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.utils.encoding import force_str
-from django.utils.functional import lazy
+from django.utils.functional import lazy, cached_property
 
 from timezone_field.backends import TimeZoneNotFoundError, get_tz_backend
 from timezone_field.choices import standard, with_gmt_offset

--- a/timezone_field/fields.py
+++ b/timezone_field/fields.py
@@ -3,7 +3,7 @@ from functools import cached_property
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.utils.encoding import force_str
-from django.utils.functional import SimpleLazyObject
+from django.utils.functional import lazy
 
 from timezone_field.backends import TimeZoneNotFoundError, get_tz_backend
 from timezone_field.choices import standard, with_gmt_offset
@@ -70,10 +70,11 @@ class TimeZoneField(models.Field):
         else:
             self._raw_choices = None
 
-        kwargs["choices"] = SimpleLazyObject(self._build_choices)
+        kwargs["choices"] = lazy(lambda: self._computed_choices, list)()
         super().__init__(*args, **kwargs)
 
-    def _build_choices(self):
+    @cached_property
+    def _computed_choices(self):
         if self._raw_choices is not None:
             values, displays = zip(*self._raw_choices)
             # Choices can be specified in two forms: either

--- a/timezone_field/forms.py
+++ b/timezone_field/forms.py
@@ -1,6 +1,8 @@
 from django import forms
 from django.core.exceptions import ValidationError
 
+from django.utils.functional import SimpleLazyObject
+
 from timezone_field.backends import TimeZoneNotFoundError, get_tz_backend
 from timezone_field.choices import standard, with_gmt_offset
 
@@ -23,20 +25,32 @@ class TimeZoneFormField(forms.TypedChoiceField):
         kwargs.setdefault("empty_value", None)
 
         if "choices" in kwargs:
-            values, displays = zip(*kwargs["choices"])
+            self._raw_choices = list(kwargs["choices"])
+        else:
+            self._raw_choices = None
+
+        self._choices_display = kwargs.pop("choices_display", None)
+        if self._choices_display not in (None, "WITH_GMT_OFFSET", "STANDARD"):
+            raise ValueError(
+                f"Unrecognized value for kwarg 'choices_display' of '{self._choices_display}'"
+            )
+
+        kwargs["choices"] = SimpleLazyObject(self._build_choices)
+        super().__init__(*args, **kwargs)
+
+    def _build_choices(self):
+        if self._raw_choices is not None:
+            values, displays = zip(*self._raw_choices)
         else:
             values = self.tz_backend.base_tzstrs
             displays = None
 
-        choices_display = kwargs.pop("choices_display", None)
-        if choices_display == "WITH_GMT_OFFSET":
+        if self._choices_display == "WITH_GMT_OFFSET":
             choices = with_gmt_offset(values, use_pytz=self.use_pytz)
-        elif choices_display == "STANDARD":
+        elif self._choices_display == "STANDARD":
             choices = standard(values)
-        elif choices_display is None:
-            choices = zip(values, displays) if displays else standard(values)
+        elif self._choices_display is None:
+            choices = list(zip(values, displays)) if displays else standard(values)
         else:
-            raise ValueError(f"Unrecognized value for kwarg 'choices_display' of '{choices_display}'")
-
-        kwargs["choices"] = choices
-        super().__init__(*args, **kwargs)
+            raise ValueError(f"Unrecognized value for kwarg 'choices_display' of '{self._choices_display}'")
+        return choices

--- a/timezone_field/forms.py
+++ b/timezone_field/forms.py
@@ -1,7 +1,6 @@
 from django import forms
 from django.core.exceptions import ValidationError
-
-from django.utils.functional import SimpleLazyObject
+from django.utils.functional import lazy, cached_property
 
 from timezone_field.backends import TimeZoneNotFoundError, get_tz_backend
 from timezone_field.choices import standard, with_gmt_offset
@@ -35,10 +34,11 @@ class TimeZoneFormField(forms.TypedChoiceField):
                 f"Unrecognized value for kwarg 'choices_display' of '{self._choices_display}'"
             )
 
-        kwargs["choices"] = SimpleLazyObject(self._build_choices)
+        kwargs["choices"] = lazy(lambda: self._computed_choices, list)()
         super().__init__(*args, **kwargs)
 
-    def _build_choices(self):
+    @cached_property
+    def _computed_choices(self):
         if self._raw_choices is not None:
             values, displays = zip(*self._raw_choices)
         else:


### PR DESCRIPTION
## Motivation
In Django, ORM model classes are instantiated immediately at startup, so any heavy operations in their init path slow down your manage.py CLI startup time. Currently, instantiating a `TimeZoneField` indirectly calls `zoneinfo.available_timezones()` twice (via ZoneInfoBackend), which performs a lot of IO and parsing. On my machines this adds 25-35ms to startup time. Not huge on its own, but Django startup times can easily build up with a few libraries being a little bit slow. I measured this with the following script:

```python
import subprocess
import timeit


PYTHON = 'python3.12'

def baseline():
    subprocess.run([PYTHON, '-c', 'import zoneinfo'])

def slow():
    subprocess.run([PYTHON, '-c', 'import zoneinfo; _ = zoneinfo.available_timezones(); _ = zoneinfo.available_timezones()'])

if __name__ == '__main__':
    N = 20

    # Take the fastest reading of all N runs
    baseline_time = min(timeit.repeat(stmt=baseline, repeat=N, number=1))
    slow_time = min(timeit.repeat(stmt=slow, repeat=N, number=1))

    diff = slow_time - baseline_time

    print(f'baseline: {baseline_time * 1000:.3f}ms')
    print(f'slow: {slow_time * 1000:.3f}ms')
    print(f'Difference: {diff * 1000:.3f}ms')
```

### Timing on Heztner CCX53

> baseline: 34.565ms
> slow: 69.756ms
> Difference: 35.191ms

### Timing on Apple M4 Pro

> baseline: 36.593ms
> slow: 62.454ms
> Difference: 25.861ms


## Solution

I fixed this by making the zoneinfo reads happen lazily. This required changing TimeZoneField's `choices` field to be a lazy object itself, which unfortunately did make the code a bit more complex. 

I only touched the ZoneInfoBackend, and left PYTZBackend alone because I don't think even has this issue - a cursory look at its source shows it lists timezones directly in the Python file, so isn't performing IO.
