### PR TITLE
Fix CI Django version specifier to pin to intended minor version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,7 +150,7 @@ jobs:
         if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         run: |
           source .venv/bin/activate
-          pip install --pre "Django~=${{ matrix.django-version }}"
+          pip install --pre "Django>=${{ matrix.django-version }}.dev0,==${{ matrix.django-version }}.*"
 
       - name: Install pytz
         if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true' && matrix.tz-engine == 'pytz'


### PR DESCRIPTION
## Summary
- The `~=` compatible release specifier (e.g. `~=5.0`) means `>=5.0, ==5.*`, which installs the latest 5.x release rather than the intended 5.0.x. For example, `dj5.0` CI jobs were actually testing Django 5.2, and `dj6.0` jobs were installing `6.1a1`.
- Change to `>=X.Y.dev0, ==X.Y.*` to correctly pin each matrix entry to its minor version while still allowing pre-releases.
- This also fixes the `dj6.1` CI jobs, which failed because `~=6.1` requires `>=6.1.0` and the only available version (`6.1a1`) is less than `6.1.0` per PEP 440.

## Test plan
- [ ] Verify CI passes with the new specifier
- [ ] Spot-check that dj5.0 jobs install Django 5.0.x, dj5.1 jobs install 5.1.x, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)